### PR TITLE
Reset transitions at the start of an interaction.

### DIFF
--- a/game/custom/03graphics.rpy
+++ b/game/custom/03graphics.rpy
@@ -248,7 +248,7 @@ init -100 python:
 
             # Also, in order to avoid showing the wrong transition to
             # people, we get rid of it in new interactions.
-            if not self.reset:
+            if not renpy.is_start_interact() and not self.reset:
                 self.transition = None
                 self.redraw()
 


### PR DESCRIPTION
This requires Ren'Py 6.99.8 to function.

It fixes an issue where a restarted interaction (which can occur from the CTC indicator being shown, various screed language hovers, etc) could cause the transition to be removed. Ren'Py 6.99.8 now has a function that can detect this condition, making it possible to program around it.